### PR TITLE
Remove unused parameter

### DIFF
--- a/jobs/app/templates/ctl
+++ b/jobs/app/templates/ctl
@@ -39,6 +39,6 @@ case $1 in
     ;;
 
   *)
-  echo "Usage: ctl {start|stop|console}" ;;
+  echo "Usage: ctl {start|stop}" ;;
 esac
 exit 0


### PR DESCRIPTION
`console` is not implemented in this script.
